### PR TITLE
Fix image sizing for team leads in roster

### DIFF
--- a/src/components/About/Roster.astro
+++ b/src/components/About/Roster.astro
@@ -170,8 +170,8 @@ subteams.sort((a, b) => {
                       title={member.fields.title}
                       image={
                         member.fields.picture == undefined
-                          ? `${placeholderImage.fields.file?.url}?fm=avif&w=300&h=300`
-                          : `${member.fields.picture.fields.file.url}?fm=avif&w=300&h=300`
+                          ? `${placeholderImage.fields.file?.url}?fm=avif`
+                          : `${member.fields.picture.fields.file.url}?fm=avif`
                       }
                     />
                   );


### PR DESCRIPTION
any person with a title in roster would load at 300x300 px instead of the full rez, fixed