### PR TITLE
re-wrote roster

### DIFF
--- a/src/components/About/Roster.astro
+++ b/src/components/About/Roster.astro
@@ -15,6 +15,7 @@ interface Roster {
     title: string;
     subteam: string;
     year: number;
+    ranking: number;
   };
   contentTypeId: string;
 }
@@ -31,185 +32,62 @@ const placeholderImage = await contentfulClient.getAsset(
 
 // -------ROSTER MEMBER SORTING------- //
 
-// Sort the roster array in alphabetical order by name of the person
-rosterResponse.items.sort((a, b) => {
-  if (a.fields.name < b.fields.name) {
-    return -1;
-  }
-
-  if (a.fields.name > b.fields.name) {
-    return 1;
-  }
-
-  return 0;
+// Extract unique years from the rosterResponse
+const rosterYearsSet = new Set<number>();
+rosterResponse.items.forEach((member) => {
+  rosterYearsSet.add(member.fields.year);
 });
 
-// Sort the roster array by whether or not the person has a photo
-rosterResponse.items.sort((a, b) => {
-  if (a.fields.picture && !b.fields.picture) {
-    return -1;
+// Convert the Set to an Array and sort in descending order
+const rosterYears = Array.from(rosterYearsSet).sort((a, b) => b - a);
+
+// Define the subteams in the desired order
+const subteams = ["Exec", "Manufacturing", "Design", "Programming", "Outreach"];
+
+// Comparator: sort by ranking (higher first), then by name (A–Z, case-insensitive)
+function compareMembers(a: Roster, b: Roster) {
+  const aRank = a.fields.ranking;
+  const bRank = b.fields.ranking;
+
+  if (aRank !== bRank) {
+    return bRank - aRank; // higher ranking first
   }
 
-  if (!a.fields.picture && b.fields.picture) {
-    return 1;
-  }
-
-  return 0;
-});
-
-const rosterYears: number[] = [];
-// For each of the years in the response, add it to the years array if it isn't already there
-rosterResponse.items.forEach((item) => {
-  if (!rosterYears.includes(item.fields.year)) {
-    rosterYears.push(item.fields.year);
-  }
-});
-rosterYears.sort((a, b) => b - a);
-
-// For anything that's not an integer, remove it from the array
-rosterYears.forEach((year) => {
-  if (!Number.isInteger(year)) {
-    rosterYears.splice(rosterYears.indexOf(year), 1);
-  }
-});
-
-// -------SUBTEAM SORTING------- //
-
-// Make an array of all the subteams
-const subteams: string[] = [];
-
-rosterResponse.items.forEach((item) => {
-  if (
-    !subteams.includes(item.fields.subteam) &&
-    item.fields.subteam != undefined
-  ) {
-    subteams.push(item.fields.subteam);
-  }
-});
-
-// Capitalize the first letter of each subteam
-subteams.forEach((subteam, index) => {
-  subteams[index] = subteam.charAt(0).toUpperCase() + subteam.slice(1);
-});
-
-// Sort the subteams so they go "exec", "manufacturing", "design", "outreach", "mentor"
-subteams.sort((a, b) => {
-  switch (true) {
-    case a === "Exec":
-      return -1;
-    case b === "Exec":
-      return 1;
-
-    case a === "Manufacturing":
-      return -1;
-    case b === "Manufacturing":
-      return 1;
-
-    case a === "Design":
-      return -1;
-    case b === "Design":
-      return 1;
-
-    case a === "Programming":
-      return -1;
-    case b === "Programming":
-      return 1;
-
-    case a === "Outreach":
-      return -1;
-    case b === "Outreach":
-      return 1;
-
-    case a === "Mentor":
-      return -1;
-    case b === "Mentor":
-      return 1;
-
-    default:
-      return 0;
-  }
-});
+  const aName = (a.fields.name || "").toLowerCase();
+  const bName = (b.fields.name || "").toLowerCase();
+  return aName.localeCompare(bName);
+}
 ---
-
 {
   rosterYears.map((year) => (
-    <div
-      class={`${year === rosterYears[0] ? "showDefault" : ""} people data`}
-      id={year.toString()}
-    >
+    <div class={`${year === rosterYears[0] ? "showDefault" : ""} people data`} id={year.toString()}>
       {subteams.map((subteam) => {
         return (
           <>
             <h4 data-aos="zoom-in" data-aos-once="true">
               {subteam} Team
             </h4>
-            {
-              // Filer out the people with titles (team leads) and map them
-              rosterResponse.items
+            <>
+              {rosterResponse.items
                 .filter(
                   (member) =>
-                    member.fields.subteam == subteam.toLowerCase() &&
-                    member.fields.year == year &&
-                    member.fields.title,
+                    member.fields.year === year &&
+                    member.fields.subteam === subteam.toLowerCase(),
                 )
-                // Sort the leads by title length
-                .sort((a, b) => {
-                  if (a.fields.title.length > b.fields.title.length) {
-                    return -1;
-                  } else if (a.fields.title.length < b.fields.title.length) {
-                    return 1;
-                  } else {
-                    return 0;
-                  }
-                })
-                // Map the leads onto the page
+                .sort(compareMembers) // Apply the fixed comparator
                 .map((member) => {
+                  const imageUrl =
+                    member.fields.picture?.fields.file.url ||
+                    placeholderImage.fields.file.url;
                   return (
                     <Person
                       name={member.fields.name}
                       title={member.fields.title}
-                      image={
-                        member.fields.picture == undefined
-                          ? `${placeholderImage.fields.file?.url}?fm=avif`
-                          : `${member.fields.picture.fields.file.url}?fm=avif`
-                      }
+                      image={imageUrl + "?fm=webp&w=1080&h=1080"}
                     />
                   );
-                })
-            }
-            {
-              // Filter out the people without titles (team members) and map them
-              rosterResponse.items
-                .filter(
-                  (member) =>
-                    member.fields.subteam == subteam.toLowerCase() &&
-                    member.fields.year == year &&
-                    member.fields.title == undefined,
-                )
-                // Sort the members by whether or not they have a picture
-                .sort((a, b) => {
-                  if (a.fields.picture && !b.fields.picture) {
-                    return -1;
-                  } else if (!a.fields.picture && b.fields.picture) {
-                    return 1;
-                  } else {
-                    return 0;
-                  }
-                })
-                .map((member) => {
-                  return (
-                    <Person
-                      name={member.fields.name}
-                      title={member.fields.title}
-                      image={
-                        member.fields.picture == undefined
-                          ? `${placeholderImage.fields.file?.url}?fm=avif`
-                          : `${member.fields.picture.fields.file.url}?fm=avif`
-                      }
-                    />
-                  );
-                })
-            }
+                })}
+            </>
           </>
         );
       })}

--- a/src/components/About/Roster.astro
+++ b/src/components/About/Roster.astro
@@ -46,17 +46,19 @@ const subteams = ["Exec", "Manufacturing", "Design", "Programming", "Outreach"];
 
 // Comparator: sort by ranking (higher first), then by name (A–Z, case-insensitive)
 function compareMembers(a: Roster, b: Roster) {
-  const aRank = a.fields.ranking;
-  const bRank = b.fields.ranking;
+  let aRank = a.fields.ranking ?? 0;
+  let bRank = b.fields.ranking ?? 0;
 
   if (aRank !== bRank) {
-    return bRank - aRank; // higher ranking first
+      console.log(`Comparing ${a.fields.name} (rank: ${aRank}) with ${b.fields.name} (rank: ${bRank})`);
+      return bRank - aRank; // higher ranking first
   }
 
   const aName = (a.fields.name || "").toLowerCase();
   const bName = (b.fields.name || "").toLowerCase();
   return aName.localeCompare(bName);
 }
+
 ---
 {
   rosterYears.map((year) => (
@@ -71,8 +73,7 @@ function compareMembers(a: Roster, b: Roster) {
               {rosterResponse.items
                 .filter(
                   (member) =>
-                    member.fields.year === year &&
-                    member.fields.subteam === subteam.toLowerCase(),
+                    member.fields.year === year && member.fields.subteam === subteam.toLowerCase(),
                 )
                 .sort(compareMembers) // Apply the fixed comparator
                 .map((member) => {


### PR DESCRIPTION
-  simplified code, removed unnecessary sort operations.
- changed image size to 1080px*1080px and format to web p
- replaced sorting leads by title length with sorting leads by a ranking 
- allowed non-leads to have rankings and be sorted to top of sub-team
- reduced overall page size from 12mb to 4mb