### PR TITLE
fixed hitboxes on navbar links for mobile

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -85,6 +85,7 @@
     flex-flow: wrap;
     align-content: center;
     justify-content: center;
+    row-gap: 20px;
   }
   #logo {
     width: 50px;
@@ -103,7 +104,10 @@
     text-decoration: none;
     color: white;
     text-decoration: underline solid transparent;
-    padding: 30px;
+    padding-left: 30px;
+    padding-right: 30px;
+    padding-top: 10px;
+    padding-bottom: 10px;
     font-size: 18px;
     border: none;
     cursor: pointer;


### PR DESCRIPTION
changed padding and vertical gap to prevent overlap of navbar link hit boxes on mobile

fixes #635 